### PR TITLE
Fix race conditions in pausable context

### DIFF
--- a/job_queue.go
+++ b/job_queue.go
@@ -116,7 +116,10 @@ func (job *JobQueueT) SetAutoPauseWaitEnabled(state bool) {
 }
 
 func (job *JobQueueT) Running() bool {
-	if job.autoPause {
+	job.mu.Lock()
+	autoPause := job.autoPause
+	job.mu.Unlock()
+	if autoPause {
 		job.WaitIfPaused()
 	}
 	return job.pCtx.Err() == nil

--- a/pausectx.go
+++ b/pausectx.go
@@ -55,7 +55,10 @@ func (pCtx *pausableContextT) Unpause() {
 }
 
 func (pCtx *pausableContextT) Paused() bool {
-	return pCtx.paused
+	pCtx.mu.Lock()
+	paused := pCtx.paused
+	pCtx.mu.Unlock()
+	return paused
 }
 
 func (pCtx *pausableContextT) WaitIfPaused() {

--- a/pausectx_threadsafe_test.go
+++ b/pausectx_threadsafe_test.go
@@ -1,0 +1,34 @@
+package jobqueue
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+// TestPausedIsThreadSafe ensures that calling Paused concurrently with
+// Pause and Unpause does not cause data races.
+func TestPausedIsThreadSafe(t *testing.T) {
+	ctx, cancel := NewPausableContext(context.Background())
+	defer cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			ctx.Pause()
+			ctx.Unpause()
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			_ = ctx.Paused()
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary
- guard PausableContext.Paused with a mutex
- read JobQueue autoPause flag under lock
- add test to ensure Paused can be called concurrently

## Testing
- `go test -run TestHandlerQueue`
- `go test -run TestPausedIsThreadSafe -race`


------
https://chatgpt.com/codex/tasks/task_e_68906b8dabec8327aff97883094c8f9c